### PR TITLE
Add base reveal animation styles for [data-reveal]

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -197,6 +197,20 @@
   padding-right: 0 !important;
 }
 
+/* =========================================================
+   Reveal animations (Cuberto-style)
+   ========================================================= */
+[data-reveal] {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 600ms ease, transform 600ms ease;
+}
+
+[data-reveal].reveal-in {
+  opacity: 1;
+  transform: none;
+}
+
 
 /* Force logo text to pure black */
 .masthead #site-nav.greedy-nav .site-title,


### PR DESCRIPTION
### Motivation
- Provide the initial and final CSS states needed for the existing intersection observer to produce a Cuberto-like reveal animation for elements marked with `data-reveal`.
- Ensure revealable elements animate with a smooth fade-and-slide effect using `opacity`, `transform`, and `transition` rather than relying solely on JS toggling.

### Description
- Updated `assets/css/custom.css` to add a base rule for `[data-reveal]` that sets `opacity: 0`, `transform: translateY(20px)`, and `transition: opacity 600ms ease, transform 600ms ease`.
- Added a visible state rule `[data-reveal].reveal-in` that sets `opacity: 1` and `transform: none` to complete the animation.
- Placed the new rules near the bottom of the file so they apply after existing header/nav overrides.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dc6b3b9f4832ebedf35e0e27e351c)