### PR TITLE
Add Cuberto-style staggered stem grid CSS

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -126,6 +126,51 @@
 /* =========================================================
    Image grid helpers
    ========================================================= */
+.stem-grid {
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  gap: clamp(1rem, 2.2vw, 2rem);
+  align-items: end;
+}
+
+.stem-card {
+  grid-column: span 4;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.stem-card img {
+  width: 100%;
+  height: 100%;
+  border-radius: 1.25rem;
+  object-fit: cover;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.18);
+}
+
+.stem-card--tall {
+  grid-row: span 2;
+  min-height: clamp(18rem, 28vw, 28rem);
+}
+
+.stem-card--small {
+  align-self: start;
+  min-height: clamp(10rem, 18vw, 18rem);
+}
+
+.stem-card--tall img,
+.stem-card--small img {
+  height: 100%;
+}
+
+.stem-card--small:nth-child(2) {
+  grid-column: 5 / span 4;
+}
+
+.stem-card--small:nth-child(3) {
+  grid-column: 9 / span 4;
+}
+
 .stem-grid__stack {
   display: grid;
   gap: 1.5rem;


### PR DESCRIPTION
### Motivation
- Create a Cuberto-like staggered hero grid to present feature cards in a cohesive visual layout.
- Provide explicit layout rules to control column structure, gaps, and vertical alignment for responsive presentation.
- Add sizing rules so tall vs small cards maintain consistent proportions across viewports.
- Improve image presentation so card images fill their containers and have rounded corners and depth.

### Description
- Added `.stem-grid` to `assets/css/custom.css` with a 12-column `grid-template-columns`, `gap`, and `align-items: end` for staggered alignment.
- Introduced `.stem-card` base with `grid-column: span 4`, flexible column layout, and image rules for `width: 100%`, `height: 100%`, `border-radius`, `object-fit: cover`, and `box-shadow`.
- Implemented `.stem-card--tall` and `.stem-card--small` modifiers with `grid-row` spanning, `min-height` clamps, and vertical alignment behavior.
- Added positioning tweaks using `.stem-card--small:nth-child(2)` and `:nth-child(3)` to stagger small cards across the 12-column grid.

### Testing
- No automated tests were executed for this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dc6a36c84832e8b15ae44e2f60679)