### PR TITLE
Add iframe previews to articles list

### DIFF
--- a/articles.md
+++ b/articles.md
@@ -9,11 +9,17 @@ Browse our latest STEM articles below.
 <div class="articles-grid">
 {% for post in site.posts %}
   <a class="article-card" href="{{ post.url | relative_url }}">
-    {% if post.image %}
-      <img src="{{ post.image | relative_url }}" alt="{{ post.title }}">
-    {% endif %}
-    <h3>{{ post.title }}</h3>
-    <p class="article-date">{{ post.date | date: "%B %d, %Y" }}</p>
+    <div class="article-frame">
+      <iframe
+        src="{{ post.url | relative_url }}"
+        title="{{ post.title }} preview"
+        loading="lazy"
+      ></iframe>
+    </div>
+    <div class="article-info">
+      <h3>{{ post.title }}</h3>
+      <p class="article-date">{{ post.date | date: "%B %d, %Y" }}</p>
+    </div>
   </a>
 {% endfor %}
 </div>

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -187,6 +187,66 @@
   letter-spacing: -0.02em;
 }
 
+/* =========================================================
+   Articles page iframe grid
+   ========================================================= */
+.articles-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 2rem;
+  margin-top: 2rem;
+}
+
+.article-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  text-decoration: none;
+  color: inherit;
+}
+
+.article-frame {
+  position: relative;
+  aspect-ratio: 4 / 3;
+  border-radius: 1.5rem;
+  overflow: hidden;
+  background: #f5f5f5;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.16);
+  transition: box-shadow 200ms ease, transform 200ms ease;
+}
+
+.article-frame iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  pointer-events: none;
+  transform: scale(0.9);
+  transform-origin: top left;
+}
+
+.article-info h3 {
+  font-size: 1.2rem;
+  margin: 0;
+}
+
+.article-date {
+  color: #6b7280;
+  font-size: 0.95rem;
+  margin: 0.25rem 0 0;
+}
+
+.article-card:hover .article-frame,
+.article-card:focus-visible .article-frame {
+  box-shadow: 0 22px 42px rgba(15, 23, 42, 0.22);
+  transform: translateY(-4px);
+}
+
+.article-card:focus-visible {
+  outline: 2px solid #111;
+  outline-offset: 6px;
+  border-radius: 1.75rem;
+}
+
 
 /* =========================================================
    NAV FIX (Minimal Mistakes / greedy-nav)


### PR DESCRIPTION
### Motivation

- Provide previews for articles directly on the Articles page so readers can see content before navigating to a post. 
- Replace the previous image-only cards with live previews while keeping `title` and `date` visible for each post. 
- Improve discovery and affordances by adding hover/focus states for the article cards. 

### Description

- Updated `articles.md` to wrap each post in an `.article-card` that contains a preview `<iframe src="{{ post.url | relative_url }}" loading="lazy"></iframe>` and a `.article-info` block with the post title and date. 
- Added styles to `assets/css/custom.css` for `.articles-grid`, `.article-card`, `.article-frame`, the iframe sizing/scale, `.article-info h3`, and `.article-date`. 
- Implemented hover and `:focus-visible` lift/outline transitions and a `pointer-events: none` rule on the iframe to keep the preview non-interactive. 
- Ensured responsive grid layout with `repeat(auto-fit, minmax(240px, 1fr))` and accessible focus outlines. 

### Testing

- Attempted to check the site tooling with `jekyll -v`, which failed because the `jekyll` command was not found (environment missing build tooling). 
- No automated site build or test suite was run for these static changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dce97b2f0832eb31082c6ac8e25c8)