### PR TITLE
Add preview images to article cards

### DIFF
--- a/_posts/2026-01-06-my-first-article.md
+++ b/_posts/2026-01-06-my-first-article.md
@@ -4,6 +4,7 @@ date: 2026-01-06
 categories: [STEM]
 tags: [ai, biology]
 layout: single
+image: /assets/images/2026-01-06-my-first-article.png
 ---
 
 1. The Carbon Alchemist: Synthetic Metabolisms and the 2026 Cell-Free Revolution

--- a/articles.md
+++ b/articles.md
@@ -10,6 +10,12 @@ Browse our latest STEM articles below.
 {% for post in site.posts %}
   <a class="article-card" href="{{ post.url | relative_url }}">
     <div class="article-frame">
+      <img
+        class="article-frame__image"
+        src="{{ post.image | relative_url }}"
+        alt="{{ post.title }}"
+        loading="lazy"
+      />
       <iframe
         src="{{ post.url | relative_url }}"
         title="{{ post.title }} preview"

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -172,13 +172,24 @@
   transition: box-shadow 200ms ease, transform 200ms ease;
 }
 
+.article-frame__image {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
 .article-frame iframe {
+  position: absolute;
+  inset: 0;
   width: 100%;
   height: 100%;
   border: 0;
   pointer-events: none;
   transform: scale(0.9);
   transform-origin: top left;
+  opacity: 0;
 }
 
 .article-info h3 {


### PR DESCRIPTION
### Motivation
- Display a cover image for each article card in the Articles grid so previews match images in `assets/images`.
- Improve the Articles page visual layout by showing a static cover image in the frame while keeping the iframe for accessibility/preview fallback.
- Provide a per-post image field so the list view can reference the correct asset.

### Description
- Render an `<img class="article-frame__image" src="{{ post.image | relative_url }}" alt="{{ post.title }}" loading="lazy" />` inside the article frame in `articles.md` before the existing `<iframe>`.
- Add `.article-frame__image` styles and make the iframe `position: absolute` with `opacity: 0` in `assets/css/custom.css` so the image covers the frame and the iframe stays hidden behind it.
- Add an `image: /assets/images/2026-01-06-my-first-article.png` front matter entry to `_posts/2026-01-06-my-first-article.md` as an example for the per-post image field.

### Testing
- Attempted to run `bundle exec jekyll serve --host 0.0.0.0 --port 4000`, which failed with: `Could not locate Gemfile or .bundle/ directory`.
- No automated site-build or UI tests are configured in this environment to validate the visual result.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695de57800a4832eb7e636b866d3ec00)