### PR TITLE
Article previews: add image layer and switch frame to 16:9

### DIFF
--- a/_posts/2026-01-06-my-first-article.md
+++ b/_posts/2026-01-06-my-first-article.md
@@ -4,6 +4,7 @@ date: 2026-01-06
 categories: [STEM]
 tags: [ai, biology]
 layout: single
+image: /assets/images/2026-01-06-my-first-article.png
 ---
 
 1. The Carbon Alchemist: Synthetic Metabolisms and the 2026 Cell-Free Revolution

--- a/articles.md
+++ b/articles.md
@@ -10,6 +10,12 @@ Browse our latest STEM articles below.
 {% for post in site.posts %}
   <a class="article-card" href="{{ post.url | relative_url }}">
     <div class="article-frame">
+      <img
+        class="article-frame__image"
+        src="{{ post.image | relative_url }}"
+        alt="{{ post.title }}"
+        loading="lazy"
+      />
       <iframe
         src="{{ post.url | relative_url }}"
         title="{{ post.title }} preview"

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -164,7 +164,7 @@
 
 .article-frame {
   position: relative;
-  aspect-ratio: 4 / 3;
+  aspect-ratio: 16 / 9;
   border-radius: 1.5rem;
   overflow: hidden;
   background: #f5f5f5;
@@ -172,13 +172,24 @@
   transition: box-shadow 200ms ease, transform 200ms ease;
 }
 
+.article-frame__image {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
 .article-frame iframe {
+  position: absolute;
+  inset: 0;
   width: 100%;
   height: 100%;
   border: 0;
   pointer-events: none;
   transform: scale(0.9);
   transform-origin: top left;
+  opacity: 0;
 }
 
 .article-info h3 {


### PR DESCRIPTION
### Motivation
- Show a static cover image for each article card so previews match assets in `/assets/images` and improve perceived loading.
- Keep the existing iframe as an accessibility/preview fallback while hiding it behind the static image.
- Standardize the article card frame to a 16:9 aspect ratio for a more modern widescreen preview.

### Description
- Updated `assets/css/custom.css` to change the article frame aspect ratio from `4 / 3` to `16 / 9` and add `.article-frame__image` styling while making the iframe absolutely positioned and `opacity: 0`.
- Inserted an `<img class="article-frame__image" ... />` before the `<iframe>` in `articles.md` so the image covers the frame with the iframe preserved as a fallback.
- Added an example `image: /assets/images/2026-01-06-my-first-article.png` front-matter entry to `_posts/2026-01-06-my-first-article.md` to demonstrate the per-post image field.
- Committed the CSS update with the message `Update article preview aspect ratio`.

### Testing
- Attempted to run `bundle exec jekyll serve --host 0.0.0.0 --port 4000`, which failed with `Could not locate Gemfile or .bundle/ directory` in this environment.
- No automated site-build, CI, or visual/UI tests were configured or run for this change in the current environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695de57800a4832eb7e636b866d3ec00)