### PR TITLE
Make navbar logo smaller and force nav text black

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -268,6 +268,7 @@
 .masthead #site-nav.greedy-nav .visible-links li a {
   padding-left: 0 !important;
   padding-right: 0 !important;
+  color: #000 !important;
 }
 
 
@@ -286,7 +287,7 @@
 /* Nudge logo up and left (Cuberto-style alignment) */
 .masthead #site-nav.greedy-nav .site-title,
 .masthead #site-nav.greedy-nav .site-title a {
-  font-size: 2rem !important;      /* keep your chosen size */
+  font-size: 1.5rem !important;      /* keep your chosen size */
   font-weight: 700 !important;
   letter-spacing: -0.03em !important;
 


### PR DESCRIPTION
### Motivation
- Reduce the visual weight of the masthead by making the site title/logo smaller in the navbar.
- Ensure all navigation link text appears as pure black for better contrast and consistent branding.
- Target the Minimal Mistakes `greedy-nav` layout to keep logo left and links right with tight spacing.

### Description
- Updated `assets/css/custom.css` to add `color: #000 !important;` to `.masthead #site-nav.greedy-nav .visible-links li a` to force nav link text black.
- Reduced the logo/site-title font size by changing the `font-size` for `.masthead #site-nav.greedy-nav .site-title` and `.site-title a` from `2rem` to `1.5rem`.
- Kept existing positioning and spacing rules for the `greedy-nav` layout to preserve alignment and spacing behavior.

### Testing
- No automated test suite was run against the site after the change.
- An attempt to check the local Jekyll version with `jekyll -v` failed because Jekyll is not installed in the environment (command not found).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965be524a40832ebb375b5b96b5ae67)