### PR TITLE
Enforce black text color site-wide

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -7,6 +7,12 @@
    Cuberto-style header (Minimal Mistakes) — tighter spacing
    ========================================================= */
 
+/* Global text color */
+body,
+body * {
+  color: #000 !important;
+}
+
 /* Less vertical space above/below the navbar */
 .masthead {
   border-bottom: none !important;


### PR DESCRIPTION
### Motivation
- Ensure all site text renders in pure black to satisfy the request to make all text font color black by overriding existing styles.

### Description
- Added a global CSS rule in `assets/css/custom.css`: `body, body * { color: #000 !important; }` which forces black text across all elements.

### Testing
- No automated tests were run; an attempt to run `jekyll --version` failed with `command not found`, and the change was committed to the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69702626622c832e90e41ac6d733bd75)