### PR TITLE
Add homepage iframe quick links

### DIFF
--- a/index.md
+++ b/index.md
@@ -19,6 +19,25 @@ title: ""
   </p>
 </section>
 
+<!-- Homepage quick links -->
+<section class="home-quick-links" data-reveal>
+  <iframe
+    title="Articles"
+    src="{{ '/articles/' | relative_url }}"
+    loading="lazy"
+  ></iframe>
+  <iframe
+    title="Contact"
+    src="{{ '/contact/' | relative_url }}"
+    loading="lazy"
+  ></iframe>
+  <iframe
+    title="About Us"
+    src="{{ '/about/' | relative_url }}"
+    loading="lazy"
+  ></iframe>
+</section>
+
 
 
 


### PR DESCRIPTION
### Motivation
- Provide quick, embedded links under the homepage hero so visitors can jump to the Articles, Contact, and About pages directly from the landing page.

### Description
- Added a `home-quick-links` section to `index.md` containing three `<iframe>` elements that load `{{ '/articles/' | relative_url }}`, `{{ '/contact/' | relative_url }}`, and `{{ '/about/' | relative_url }}` with `loading="lazy"`.

### Testing
- Attempted to preview the site with `bundle exec jekyll serve --host 0.0.0.0 --port 4000` but the command failed due to a missing `Gemfile`/`.bundle` directory, so no build preview tests completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697028387bf8832ebec0ed32d35bd8bb)