### PR TITLE
Use ChatGPT artwork for article covers and evenly space homepage iframes

### DIFF
--- a/articles.md
+++ b/articles.md
@@ -12,8 +12,8 @@ Browse our latest STEM articles below.
     <div class="article-frame">
       <img
         class="article-frame__image"
-        src="{{ post.image | relative_url }}"
-        alt="{{ post.title }}"
+        src="{{ '/assets/images/ChatGPT Image Jan 20, 2026, 05_35_28 PM.png' | relative_url | replace: ' ', '%20' }}"
+        alt="ChatGPT artwork"
         loading="lazy"
       />
       <iframe

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -151,6 +151,23 @@ body * {
 }
 
 /* =========================================================
+   Homepage quick link iframes
+   ========================================================= */
+.home-quick-links {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 2rem;
+  margin: 2rem 0;
+}
+
+.home-quick-links iframe {
+  width: 100%;
+  height: 100%;
+  min-height: 220px;
+  border: 0;
+}
+
+/* =========================================================
    Articles page iframe grid
    ========================================================= */
 .articles-grid {


### PR DESCRIPTION
### Motivation
- Provide a consistent, presentable cover for article iframe previews by using a single artwork image instead of per-post images.
- Improve layout of the homepage quick-link iframes so they are spaced evenly and adapt responsively across viewports.

### Description
- Replace the article card cover image reference in `articles.md` to use the ChatGPT artwork at `assets/images/ChatGPT Image Jan 20, 2026, 05_35_28 PM.png` and URL-encode spaces using `replace: ' ', '%20'`.
- Add a new CSS block in `assets/css/custom.css` for `.home-quick-links` that applies a responsive grid, gap spacing, and styles the quick-link `iframe` with a `min-height` and reset `border`.
- The articles iframe preview markup and existing article-grid styles are otherwise unchanged to preserve preview behavior.

### Testing
- No automated test suite was executed for this change.
- An environment check `jekyll --version` was attempted to validate build tooling but the command was not available in the environment. 
- File changes were applied to `articles.md` and `assets/css/custom.css` as shown in the diff.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69702e47982c832ebab6c81baa5645e3)