### PR TITLE
Reapply ChatGPT article cover and restore homepage iframe spacing

### DIFF
--- a/articles.md
+++ b/articles.md
@@ -12,8 +12,8 @@ Browse our latest STEM articles below.
     <div class="article-frame">
       <img
         class="article-frame__image"
-        src="{{ post.image | relative_url }}"
-        alt="{{ post.title }}"
+        src="{{ '/assets/images/ChatGPT Image Jan 20, 2026, 05_35_28 PM.png' | relative_url | replace: ' ', '%20' }}"
+        alt="ChatGPT artwork"
         loading="lazy"
       />
       <iframe

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -151,6 +151,23 @@ body * {
 }
 
 /* =========================================================
+   Homepage quick link iframes
+   ========================================================= */
+.home-quick-links {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 2rem;
+  margin: 2rem 0;
+}
+
+.home-quick-links iframe {
+  width: 100%;
+  height: 100%;
+  min-height: 220px;
+  border: 0;
+}
+
+/* =========================================================
    Articles page iframe grid
    ========================================================= */
 .articles-grid {


### PR DESCRIPTION
### Motivation
- Restore the UI changes that were previously reverted so article previews use a consistent artwork and homepage quick-links are spaced responsively.
- Provide a predictable fallback cover for iframe previews to avoid layout/content issues when posts lack images.

### Description
- Replace per-post cover usage in `articles.md` with a fixed ChatGPT artwork by setting the `img` `src` to `'/assets/images/ChatGPT Image Jan 20, 2026, 05_35_28 PM.png' | relative_url | replace: ' ', '%20'` and `alt` to `"ChatGPT artwork"`.
- Add a new CSS block in `assets/css/custom.css` introducing `.home-quick-links` grid rules and `.home-quick-links iframe` sizing and border resets to evenly space homepage iframes.
- Preserve the existing `.articles-grid` and article iframe markup so preview behavior remains unchanged except for the cover image.

### Testing
- Verified repository state and reapplied the reverted changes using `git log -1 --oneline` and `git revert --no-edit HEAD`, both commands completed successfully.
- Inspected the updated files with `nl -ba articles.md` and `nl -ba assets/css/custom.css` to confirm the intended edits were present.
- No automated test suite or build (e.g., `jekyll build`) was run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69702e47982c832ebab6c81baa5645e3)