### PR TITLE
Link homepage articles iframe to articles tab

### DIFF
--- a/index.md
+++ b/index.md
@@ -21,11 +21,14 @@ title: ""
 
 <!-- Homepage quick links -->
 <section class="home-quick-links" data-reveal>
-  <iframe
-    title="Articles"
-    src="{{ '/assets/images/chatgpt-logo.svg' | relative_url }}"
-    loading="lazy"
-  ></iframe>
+  <a href="{{ '/articles/' | relative_url }}" aria-label="Read our articles">
+    <iframe
+      title="Articles"
+      src="{{ '/assets/images/ChatGPT Image Jan 20, 2026, 05_35_28 PM.png' | relative_url }}"
+      loading="lazy"
+      style="pointer-events: none;"
+    ></iframe>
+  </a>
   <iframe
     title="Contact"
     src="{{ '/contact/' | relative_url }}"


### PR DESCRIPTION
### Motivation
- Make the leftmost quick-link on the homepage navigate to the articles tab while using the requested ChatGPT image as the iframe cover.

### Description
- Wrapped the leftmost iframe in an anchor linking to `'/articles/'`, replaced its `src` with `'/assets/images/ChatGPT Image Jan 20, 2026, 05_35_28 PM.png'`, added `style="pointer-events: none;"` to the iframe, and set an `aria-label` on the anchor in `index.md`.

### Testing
- Ran `bundle exec jekyll build` (failed: missing Gemfile) and `jekyll build` (failed: command not found), so a site build was not produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697acd242eec832e9f230cfbe012a721)