### PR TITLE
Make left homepage iframe display cover image full-bleed

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -160,11 +160,31 @@ body * {
   margin: 2rem 0;
 }
 
+.home-quick-links__card {
+  position: relative;
+  display: block;
+  aspect-ratio: 16 / 10;
+  min-height: 240px;
+  border-radius: 1.75rem;
+  overflow: hidden;
+  background: #f6f3ef;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.16);
+}
+
 .home-quick-links iframe {
   width: 100%;
   height: 100%;
   min-height: 220px;
   border: 0;
+}
+
+.home-quick-links__frame {
+  display: block;
+  width: 100%;
+  height: 100%;
+  min-height: 100%;
+  border: 0;
+  pointer-events: none;
 }
 
 /* =========================================================

--- a/index.md
+++ b/index.md
@@ -21,12 +21,34 @@ title: ""
 
 <!-- Homepage quick links -->
 <section class="home-quick-links" data-reveal>
-  <a href="{{ '/articles/' | relative_url }}" aria-label="Read our articles">
+  <a class="home-quick-links__card" href="{{ '/articles/' | relative_url }}" aria-label="Read our articles">
     <iframe
+      class="home-quick-links__frame"
       title="Articles"
-      src="{{ '/assets/images/ChatGPT Image Jan 20, 2026, 05_35_28 PM.png' | relative_url }}"
       loading="lazy"
-      style="pointer-events: none;"
+      srcdoc="<!doctype html>
+      <html lang='en'>
+        <head>
+          <meta charset='utf-8' />
+          <style>
+            html, body { height: 100%; margin: 0; }
+            body {
+              display: flex;
+              align-items: center;
+              justify-content: center;
+              background: #f6f3ef;
+            }
+            img {
+              width: 100%;
+              height: 100%;
+              object-fit: contain;
+            }
+          </style>
+        </head>
+        <body>
+          <img src='{{ '/assets/images/ChatGPT Image Jan 20, 2026, 05_35_28 PM.png' | relative_url }}' alt='Explore STEM illustration' />
+        </body>
+      </html>"
     ></iframe>
   </a>
   <iframe


### PR DESCRIPTION
### Motivation
- The leftmost homepage quick-link iframe should show the article cover art as a full, styled card instead of displaying the image file URL raw inside the iframe. 
- The change aims to provide a consistent rounded card visual and ensure the image scales and centers correctly inside the iframe.

### Description
- Replaced the plain `iframe` that loaded the image URL with an `iframe` using `srcdoc` that embeds a minimal HTML wrapper and an `img` tag so the image can be centered and scaled with `object-fit: contain` (file: `index.md`).
- Added a wrapper link class `.home-quick-links__card` with `aspect-ratio`, rounded corners, background and shadow to create the cover card look (file: `assets/css/custom.css`).
- Added `.home-quick-links__frame` to ensure the iframe fills the card and to disable pointer events so the whole card remains clickable (file: `assets/css/custom.css`).

### Testing
- Attempted to run `jekyll serve` to preview the site but the command failed because `jekyll` is not available in the environment. 
- No automated test suite was available to run against these front-end changes in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ad184f1f4832e822d0626bab2ebee)