### PR TITLE
Display monkey.png in homepage middle iframe via `srcdoc`

### DIFF
--- a/index.md
+++ b/index.md
@@ -52,9 +52,32 @@ title: ""
     ></iframe>
   </a>
   <iframe
+    class="home-quick-links__frame"
     title="Contact"
-    src="{{ '/contact/' | relative_url }}"
     loading="lazy"
+    srcdoc="<!doctype html>
+      <html lang='en'>
+        <head>
+          <meta charset='utf-8' />
+          <style>
+            html, body { height: 100%; margin: 0; }
+            body {
+              display: flex;
+              align-items: center;
+              justify-content: center;
+              background: #f6f3ef;
+            }
+            img {
+              width: 100%;
+              height: 100%;
+              object-fit: contain;
+            }
+          </style>
+        </head>
+        <body>
+          <img src='{{ '/assets/images/monkey.png' | relative_url }}' alt='Monkey illustration' />
+        </body>
+      </html>"
   ></iframe>
   <iframe
     title="About Us"


### PR DESCRIPTION
### Motivation
- Ensure the middle quick-link iframe on the homepage displays the full `monkey.png` cover image and scales the image to the card instead of loading the contact page.

### Description
- Replaced the middle iframe that previously pointed to the contact page with an inline `srcdoc` HTML payload that centers and renders `/assets/images/monkey.png` using an `img` styled with `width: 100%; height: 100%; object-fit: contain;` and added `class="home-quick-links__frame"` to the iframe.
- Change made in `index.md` only.

### Testing
- Ran `ls assets/images` which succeeded and shows `monkey.png` present.
- Ran `jekyll -v` to attempt a local build which failed because `jekyll` is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ad532bedc832e939c4b424e39d097)