### PR TITLE
Link middle homepage card to About

### DIFF
--- a/index.md
+++ b/index.md
@@ -51,34 +51,36 @@ title: ""
       </html>"
     ></iframe>
   </a>
-  <iframe
-    class="home-quick-links__frame"
-    title="Contact"
-    loading="lazy"
-    srcdoc="<!doctype html>
-      <html lang='en'>
-        <head>
-          <meta charset='utf-8' />
-          <style>
-            html, body { height: 100%; margin: 0; }
-            body {
-              display: flex;
-              align-items: center;
-              justify-content: center;
-              background: #f6f3ef;
-            }
-            img {
-              width: 100%;
-              height: 100%;
-              object-fit: contain;
-            }
-          </style>
-        </head>
-        <body>
-          <img src='{{ '/assets/images/monkey.png' | relative_url }}' alt='Monkey illustration' />
-        </body>
-      </html>"
-  ></iframe>
+  <a class="home-quick-links__card" href="{{ '/about/' | relative_url }}" aria-label="Learn more about Genova">
+    <iframe
+      class="home-quick-links__frame"
+      title="About Us"
+      loading="lazy"
+      srcdoc="<!doctype html>
+        <html lang='en'>
+          <head>
+            <meta charset='utf-8' />
+            <style>
+              html, body { height: 100%; margin: 0; }
+              body {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                background: #f6f3ef;
+              }
+              img {
+                width: 100%;
+                height: 100%;
+                object-fit: contain;
+              }
+            </style>
+          </head>
+          <body>
+            <img src='{{ '/assets/images/monkey.png' | relative_url }}' alt='Monkey illustration' />
+          </body>
+        </html>"
+    ></iframe>
+  </a>
   <iframe
     title="About Us"
     src="{{ '/about/' | relative_url }}"


### PR DESCRIPTION
### Motivation
- Make the middle quick-link on the homepage navigate to the About page and ensure the `monkey.png` cover is centered and fully visible.

### Description
- Updated `index.md` to wrap the middle quick-link iframe in an `<a class="home-quick-links__card" href="{{ '/about/' | relative_url }}">` so clicking the card opens the About page while keeping the iframe `srcdoc` that displays `assets/images/monkey.png` with `object-fit: contain` for full-image centering.

### Testing
- No automated tests were run for this static content change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ad6ff9b3c832e94ad3ba68d24d6e3)