### PR TITLE
Update rightmost homepage quick-link to About with centered cover image

### DIFF
--- a/index.md
+++ b/index.md
@@ -81,11 +81,36 @@ title: ""
         </html>"
     ></iframe>
   </a>
-  <iframe
-    title="About Us"
-    src="{{ '/about/' | relative_url }}"
-    loading="lazy"
-  ></iframe>
+  <a class="home-quick-links__card" href="{{ '/about/' | relative_url }}" aria-label="Learn more about Genova">
+    <iframe
+      class="home-quick-links__frame"
+      title="About Us"
+      loading="lazy"
+      srcdoc="<!doctype html>
+        <html lang='en'>
+          <head>
+            <meta charset='utf-8' />
+            <style>
+              html, body { height: 100%; margin: 0; }
+              body {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                background: #f6f3ef;
+              }
+              img {
+                width: 100%;
+                height: 100%;
+                object-fit: contain;
+              }
+            </style>
+          </head>
+          <body>
+            <img src='{{ '/assets/images/monkeymonkeymonkey.png' | relative_url }}' alt='Monkey illustration' />
+          </body>
+        </html>"
+    ></iframe>
+  </a>
 </section>
 
 


### PR DESCRIPTION
### Motivation
- Make the rightmost quick-link on the homepage navigate to the About page and present a dedicated cover image. 
- Ensure the cover image is fully visible and centered so the full artwork is displayed consistently with the other quick-link tiles.

### Description
- Replace the standalone iframe with an anchor-wrapped iframe using the `home-quick-links__card` and `home-quick-links__frame` markup so the tile links to the About page. 
- Use an inline `srcdoc` iframe that embeds a small HTML document which centers content with flexbox and displays an `<img>` styled with `width: 100%`, `height: 100%`, and `object-fit: contain`. 
- Point the iframe image source to `assets/images/monkeymonkeymonkey.png` so the new cover is used.

### Testing
- Served the site locally with `python -m http.server` and confirmed the homepage loads and the quick-links area renders. 
- Captured a screenshot using a Playwright script which saved `artifacts/homepage-quick-links.png`, and the render showed the updated rightmost tile as expected. 
- Verified the updated markup is present in `index.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ad99442d4832e93cb485dfc3b4977)