### PR TITLE
Point middle homepage quick link to contact page

### DIFF
--- a/index.md
+++ b/index.md
@@ -51,7 +51,7 @@ title: ""
       </html>"
     ></iframe>
   </a>
-  <a class="home-quick-links__card" href="{{ '/about/' | relative_url }}" aria-label="Learn more about Genova">
+  <a class="home-quick-links__card" href="{{ '/contact/' | relative_url }}" aria-label="Contact Genova">
     <iframe
       class="home-quick-links__frame"
       title="About Us"


### PR DESCRIPTION
### Motivation
- Update the middle homepage quick-link so it navigates to the contact page while keeping the same visual cover image.

### Description
- Change in `index.md`: the middle anchor's `href` was updated from `"{{ '/about/' | relative_url }}"` to `"{{ '/contact/' | relative_url }}"` and the `aria-label` was updated to `Contact Genova`, while the iframe `srcdoc` and image remain unchanged.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697adc3f254c832e88e05ee6421f0779)