### PR TITLE
Make homepage iframe images cover frames

### DIFF
--- a/index.md
+++ b/index.md
@@ -33,15 +33,13 @@ title: ""
           <style>
             html, body { height: 100%; margin: 0; }
             body {
-              display: flex;
-              align-items: center;
-              justify-content: center;
               background: #f6f3ef;
             }
             img {
               width: 100%;
               height: 100%;
-              object-fit: contain;
+              display: block;
+              object-fit: cover;
             }
           </style>
         </head>
@@ -63,15 +61,13 @@ title: ""
             <style>
               html, body { height: 100%; margin: 0; }
               body {
-                display: flex;
-                align-items: center;
-                justify-content: center;
                 background: #f6f3ef;
               }
               img {
                 width: 100%;
                 height: 100%;
-                object-fit: contain;
+                display: block;
+                object-fit: cover;
               }
             </style>
           </head>
@@ -93,15 +89,13 @@ title: ""
             <style>
               html, body { height: 100%; margin: 0; }
               body {
-                display: flex;
-                align-items: center;
-                justify-content: center;
                 background: #f6f3ef;
               }
               img {
                 width: 100%;
                 height: 100%;
-                object-fit: contain;
+                display: block;
+                object-fit: cover;
               }
             </style>
           </head>


### PR DESCRIPTION
### Motivation
- The quick-link iframes on the homepage used `object-fit: contain` and flex centering causing letterboxing, so images did not fill their iframe frames like the articles view.

### Description
- Update the `srcdoc` inline styles for the three homepage quick-link iframes in `index.md` to remove flex centering and keep only the page background.
- Change the iframe images to `display: block` and `object-fit: cover` so each image fills its frame edge-to-edge.

### Testing
- Running `bundle exec jekyll serve --host 0.0.0.0 --port 4000` failed due to a missing `Gemfile` in the environment.  
- Serving the site with `python -m http.server 4000 --bind 0.0.0.0` succeeded and served the updated homepage.  
- A Playwright screenshot run completed and produced `artifacts/home-quick-links.png`, confirming the iframes render with images covering their frames.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697addc74608832eaae065c72ea8261c)