### PR TITLE
Use per-article cover images in articles grid

### DIFF
--- a/articles.md
+++ b/articles.md
@@ -8,11 +8,12 @@ Browse our latest STEM articles below.
 
 <div class="articles-grid">
 {% for post in site.posts %}
+  {% assign cover_image = post.image | default: '/assets/images/ChatGPT Image Jan 20, 2026, 05_35_28 PM.png' %}
   <a class="article-card" href="{{ post.url | relative_url }}">
     <div class="article-frame">
       <img
         class="article-frame__image"
-        src="{{ '/assets/images/ChatGPT Image Jan 20, 2026, 05_35_28 PM.png' | relative_url | replace: ' ', '%20' }}"
+        src="{{ cover_image | relative_url | replace: ' ', '%20' }}"
         alt="ChatGPT artwork"
         loading="lazy"
       />


### PR DESCRIPTION
### Motivation
- Replace the hardcoded cover image in the articles grid with each post's `image` front matter so article cards display their intended cover (for example, the My First Article cover). 

### Description
- Update `articles.md` to assign `cover_image = post.image | default: '/assets/images/ChatGPT Image Jan 20, 2026, 05_35_28 PM.png'` and use `{{ cover_image | relative_url | replace: ' ', '%20' }}` for the `<img>` `src` in the articles grid. 

### Testing
- Ran `nl -ba articles.md` to inspect the file and confirm the new `cover_image` assignment and usage, which showed the expected changes (succeeded).
- Ran `jekyll -v` to attempt a local build/preview but the command is not available in the environment, so site build verification was not possible (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697aee107de4832e8cd6a941712d4a6b)