### PR TITLE
Remove Team link from navigation

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -3,7 +3,5 @@ main:
     url: /articles/
   - title: "About us"
     url: /about/
-  - title: "Team"
-    url: /team/
   - title: "Contact"
     url: /contact/


### PR DESCRIPTION
### Motivation
- Remove the Team tab from the site navigation by deleting its entry in `_data/navigation.yml`.

### Description
- Deleted the `Team` menu item lines in `_data/navigation.yml` so the main navigation no longer includes the `/team/` link.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697af01d3758832ead432b4ae80ab25a)