### PR TITLE
Nudge navbar logo further left

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -336,5 +336,5 @@ body * {
 
   position: relative;
   top: -6px;        /* move UP → adjust between -4px and -10px */
-  left: -14px;      /* move LEFT → adjust between -8px and -20px */
+  left: -18px;      /* move LEFT → adjust between -8px and -20px */
 }


### PR DESCRIPTION
### Motivation
- Tweak header alignment so the Genova logo sits slightly closer to the left edge of the navbar.

### Description
- Modify `assets/css/custom.css` to change the `.masthead #site-nav.greedy-nav .site-title` left offset from `-14px` to `-18px`, moving the logo further left.

### Testing
- No automated tests were run; attempting to start the local site with `bundle exec jekyll serve` failed due to a missing `Gemfile`, and the change was inspected in `assets/css/custom.css` and committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697af3217c48832e992a8b12dd0c6868)