### PR TITLE
Update About page layout and typography

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -1,1 +1,4 @@
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Raleway:wght@400;500&family=Roboto:wght@700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="{{ '/assets/css/custom.css' | relative_url }}">

--- a/about.md
+++ b/about.md
@@ -4,6 +4,33 @@ title: About
 permalink: /about/
 ---
 
-Genova is a student-led organization focused on publishing high-quality STEM articles.
+<section class="about-page">
+  <div class="about-section">
+    <div class="about-copy">
+      <h2 class="about-title">About Genova Global</h2>
+      <p class="about-text">
+        At Genova Global, we believe the next generation of scholars doesn't just need to read
+        about the world—they need to build it. We are dedicated to sparking a lifelong passion
+        for STEM (Science, Technology, Engineering, and Math) in youth through bridging the gap
+        between just watching videos and real hands-on work.
+      </p>
+    </div>
+    <div class="about-image">
+      <img src="{{ '/assets/images/hiker.png' | relative_url }}" alt="Hiker celebrating at sunrise" />
+    </div>
+  </div>
 
-Our mission is to make science and technology accessible, engaging, and inspiring.
+  <div class="about-section about-section--reverse">
+    <div class="about-image">
+      <img src="{{ '/assets/images/handshake.png.png' | relative_url }}" alt="Partners shaking hands" />
+    </div>
+    <div class="about-copy">
+      <h2 class="about-title">Our Mission</h2>
+      <p class="about-text">
+        To inspire and equip young minds with the critical thinking, creativity, and technical
+        skills necessary to navigate a rapidly changing world due to constant innovation. We
+        strive to make high-quality STEM knowledge accessible, inclusive, and—above all—hands-on.
+      </p>
+    </div>
+  </div>
+</section>

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -338,3 +338,71 @@ body * {
   top: -6px;        /* move UP → adjust between -4px and -10px */
   left: -20px;      /* move LEFT → adjust between -8px and -20px */
 }
+
+/* =========================================================
+   About page layout
+   ========================================================= */
+
+.about-page {
+  display: flex;
+  flex-direction: column;
+  gap: 3.5rem;
+  padding: 1.5rem 0 3rem;
+}
+
+.about-section {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 3rem;
+  align-items: center;
+}
+
+.about-section--reverse {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.about-section--reverse .about-copy {
+  order: 2;
+}
+
+.about-section--reverse .about-image {
+  order: 1;
+}
+
+.about-copy {
+  max-width: 36rem;
+}
+
+.about-title {
+  font-family: "Roboto", "Helvetica Neue", Arial, sans-serif;
+  font-weight: 700;
+  font-size: clamp(1.75rem, 2.5vw, 2.4rem);
+  margin-bottom: 1rem;
+}
+
+.about-text {
+  font-family: "Raleway", "Helvetica Neue", Arial, sans-serif;
+  font-size: 1.05rem;
+  line-height: 1.7;
+  margin: 0;
+}
+
+.about-image img {
+  width: 100%;
+  height: auto;
+  border-radius: 2.5rem;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.16);
+  display: block;
+}
+
+@media (max-width: 900px) {
+  .about-section,
+  .about-section--reverse {
+    grid-template-columns: 1fr;
+  }
+
+  .about-section--reverse .about-copy,
+  .about-section--reverse .about-image {
+    order: initial;
+  }
+}


### PR DESCRIPTION
### Motivation
- Implement the requested About page design as a two-section layout that uses `assets/images/hiker.png` for the top-left image and `assets/images/handshake.png.png` for the bottom-left image, with headings in bold Roboto and body text in Raleway.

### Description
- Replace the existing `about.md` content with a semantic two-section layout (`.about-page` / `.about-section`) that pairs copy and imagery.
- Add responsive styling in `assets/css/custom.css` to create the two-column grid, image treatment, spacing, and typography rules for `.about-title` and `.about-text`.
- Load Roboto and Raleway from Google Fonts by adding the font `link` tags to `_includes/head/custom.html` so headings and body copy use the requested fonts.
- Reference the provided images using Jekyll `relative_url` paths (`/assets/images/hiker.png` and `/assets/images/handshake.png.png`).

### Testing
- Attempted to preview the site with `jekyll serve --host 0.0.0.0 --port 4000`, which failed because `jekyll` is not installed in the environment.
- No other automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e61d6bbb0832e9b5ec4d517789901)