### PR TITLE
Update About page layout to match target design

### DIFF
--- a/about.md
+++ b/about.md
@@ -5,7 +5,7 @@ permalink: /about/
 ---
 
 <section class="about-page">
-  <div class="about-section">
+  <div class="about-section about-section--intro">
     <div class="about-copy">
       <h2 class="about-title">About Genova Global</h2>
       <p class="about-text">
@@ -20,7 +20,7 @@ permalink: /about/
     </div>
   </div>
 
-  <div class="about-section about-section--reverse">
+  <div class="about-section about-section--reverse about-section--mission">
     <div class="about-image">
       <img src="{{ '/assets/images/handshake.png.png' | relative_url }}" alt="Partners shaking hands" />
     </div>

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -346,14 +346,14 @@ body * {
 .about-page {
   display: flex;
   flex-direction: column;
-  gap: 3.5rem;
-  padding: 1.5rem 0 3rem;
+  gap: 4rem;
+  padding: 2rem 0 3.5rem;
 }
 
 .about-section {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 3rem;
+  gap: 4rem;
   align-items: center;
 }
 
@@ -371,12 +371,14 @@ body * {
 
 .about-copy {
   max-width: 36rem;
+  margin: 0 auto;
+  text-align: center;
 }
 
 .about-title {
   font-family: "Roboto", "Helvetica Neue", Arial, sans-serif;
   font-weight: 700;
-  font-size: clamp(1.75rem, 2.5vw, 2.4rem);
+  font-size: clamp(1.9rem, 2.6vw, 2.6rem);
   margin-bottom: 1rem;
 }
 
@@ -387,12 +389,27 @@ body * {
   margin: 0;
 }
 
+.about-image {
+  display: flex;
+  justify-content: center;
+}
+
 .about-image img {
   width: 100%;
   height: auto;
   border-radius: 2.5rem;
-  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.16);
   display: block;
+}
+
+.about-section--intro .about-image img {
+  max-width: 520px;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.16);
+}
+
+.about-section--mission .about-image img {
+  max-width: 420px;
+  border-radius: 1.75rem;
+  border: 1px solid #d1d5db;
 }
 
 @media (max-width: 900px) {


### PR DESCRIPTION
### Motivation
- Align the About page with the provided target design by improving section structure, spacing, and image treatments. 
- Provide section-specific styling so intro and mission areas can receive distinct layout and visual tweaks.

### Description
- Added section classes in `about.md` (`about-section--intro` and `about-section--mission`) to enable targeted styling. 
- Updated `assets/css/custom.css` to increase vertical/horizontal spacing, center the copy, and slightly enlarge the section heading with `clamp()` adjustments. 
- Introduced `.about-image` flex centering and section-specific image rules (max-widths, shadow only for the intro image, and a bordered, subtler radius for the mission image). 
- Files modified: `about.md` and `assets/css/custom.css`.

### Testing
- Attempted to run the site with `bundle exec jekyll serve --host 0.0.0.0 --port 4000`, which failed due to a missing `Gemfile` (no local Jekyll run). 
- Verified changes were staged and committed successfully with `git commit` (commit completed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e6955fd44832ea494fb82f5088269)