### PR TITLE
Limit text centering to homepage

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -372,7 +372,7 @@ body * {
 .about-copy {
   max-width: 36rem;
   margin: 0 auto;
-  text-align: center;
+  text-align: left;
 }
 
 .about-title {


### PR DESCRIPTION
### Motivation
- Restrict centered text styling so the homepage hero remains centered while other pages (like About) use normal left-aligned copy for better readability.

### Description
- Update `assets/css/custom.css` to change `.about-copy` from `text-align: center;` to `text-align: left;` so centering only applies to the homepage hero.

### Testing
- Attempted to run `jekyll serve --host 0.0.0.0 --port 4000` to validate the change locally but `jekyll` is not installed in the environment, so no live preview was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697eb7c9b410832eb63339926225da04)