### PR TITLE
Refine About page layout and typography

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -347,7 +347,9 @@ body * {
   display: flex;
   flex-direction: column;
   gap: 4rem;
-  padding: 2rem 0 3.5rem;
+  padding: 2.5rem 1.5rem 4rem;
+  max-width: 1200px;
+  margin: 0 auto;
 }
 
 .about-section {
@@ -370,15 +372,15 @@ body * {
 }
 
 .about-copy {
-  max-width: 36rem;
+  max-width: 34rem;
   margin: 0 auto;
-  text-align: left;
+  text-align: center;
 }
 
 .about-title {
   font-family: "Roboto", "Helvetica Neue", Arial, sans-serif;
   font-weight: 700;
-  font-size: clamp(1.9rem, 2.6vw, 2.6rem);
+  font-size: clamp(2rem, 2.6vw, 2.8rem);
   margin-bottom: 1rem;
 }
 
@@ -395,19 +397,19 @@ body * {
 }
 
 .about-image img {
-  width: 100%;
+  width: min(520px, 100%);
   height: auto;
   border-radius: 2.5rem;
   display: block;
 }
 
 .about-section--intro .about-image img {
-  max-width: 520px;
+  max-width: 540px;
   box-shadow: 0 18px 36px rgba(15, 23, 42, 0.16);
 }
 
 .about-section--mission .about-image img {
-  max-width: 420px;
+  max-width: 540px;
   border-radius: 1.75rem;
   border: 1px solid #d1d5db;
 }


### PR DESCRIPTION
### Motivation
- Match the provided target design by widening and centering the About page content and aligning copy and imagery for better visual balance.
- Improve typographic scale and text alignment so section headings and body copy read more like the reference image.
- Make images more consistent in size across the intro and mission blocks to better match the intended layout.

### Description
- Updated `assets/css/custom.css` to set `.about-page` padding, add `max-width: 1200px`, and center the page with `margin: 0 auto`.
- Centered the copy by changing `.about-copy` to `text-align: center` and reduced `max-width` to `34rem` for tighter measure.
- Increased heading scale by adjusting `.about-title` to `font-size: clamp(2rem, 2.6vw, 2.8rem)` and constrained image sizing with `.about-image img { width: min(520px, 100%); }`.
- Increased the max widths for `.about-section--intro .about-image img` and `.about-section--mission .about-image img` to `540px` to better match the target proportions.

### Testing
- Attempted to serve the site with `bundle exec jekyll serve`, which failed due to a missing `Gemfile` so a live preview could not be generated (failed).
- Inspected the updated file contents of `assets/css/custom.css` after the changes to validate the diff and ensure the intended rules were applied (succeeded).
- No automated unit tests exist for these static style changes, so visual verification is recommended after deploying or running a local Jekyll build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ebb74a768832ea187ec19c109a0ed)