### PR TITLE
Adjust About page layout spacing and width

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -98,6 +98,11 @@ body * {
   padding-top: 0 !important;
 }
 
+/* Wider single pages to support the About layout */
+.layout--single .page__inner-wrap {
+  max-width: 1200px;
+}
+
 /* =========================================================
    Homepage statement hero (centered text block)
    ========================================================= */
@@ -356,7 +361,7 @@ body * {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 4rem;
-  align-items: center;
+  align-items: start;
 }
 
 .about-section--reverse {


### PR DESCRIPTION
### Motivation

- Ensure the About page matches the intended two-column design by widening the single-page content container and top-aligning grid rows so images line up with their copy.

### Description

- Update `assets/css/custom.css` to add `.layout--single .page__inner-wrap { max-width: 1200px; }` and change `.about-section` from `align-items: center;` to `align-items: start;` to top-align the grid items.

### Testing

- Attempted to preview the site with `jekyll serve`, but `jekyll` is not installed in the environment so no automated rendering tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fb48ef840832e9b5d25be6b601551)