### PR TITLE
Add About page markup and styling with Hiker and Handshake images

### DIFF
--- a/about.md
+++ b/about.md
@@ -3,3 +3,35 @@ layout: single
 title: About
 permalink: /about/
 ---
+
+<section class="about-genova">
+  <div class="about-genova__row">
+    <div class="about-genova__text">
+      <h1>About Genova Global</h1>
+      <p>
+        At Genova Global, we believe the next generation of scholars doesn&apos;t just need
+        to read about the world—they need to build it. We are dedicated to sparking a
+        lifelong passion for STEM (Science, Technology, Engineering, and Math) in youth
+        through bridging the gap between just watching videos and real hands-on work.
+      </p>
+    </div>
+    <div class="about-genova__media">
+      <img src="/assets/images/hiker.png" alt="Hiker celebrating at sunrise" />
+    </div>
+  </div>
+
+  <div class="about-genova__row about-genova__row--reverse">
+    <div class="about-genova__media">
+      <img src="/assets/images/handshake.png.png" alt="Handshake partnership" />
+    </div>
+    <div class="about-genova__text">
+      <h2>Our Mission</h2>
+      <p>
+        To inspire and equip young minds with the critical thinking, creativity, and
+        technical skills necessary to navigate a rapidly changing world due to constant
+        innovation. We strive to make high-quality STEM knowledge accessible, inclusive,
+        and—above all—hands-on.
+      </p>
+    </div>
+  </div>
+</section>

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -343,3 +343,66 @@ body * {
   top: -6px;        /* move UP → adjust between -4px and -10px */
   left: -20px;      /* move LEFT → adjust between -8px and -20px */
 }
+
+/* =========================================================
+   About page layout
+   ========================================================= */
+.about-genova {
+  display: grid;
+  gap: 3rem;
+  padding: 2rem 0 3.5rem;
+}
+
+.about-genova__row {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 3rem;
+  align-items: center;
+}
+
+.about-genova__row--reverse {
+  grid-auto-flow: dense;
+}
+
+.about-genova__text {
+  text-align: center;
+  font-family: "Raleway", sans-serif;
+  font-size: 1.05rem;
+  line-height: 1.7;
+  max-width: 520px;
+  margin: 0 auto;
+}
+
+.about-genova__text h1,
+.about-genova__text h2 {
+  font-family: "Roboto", sans-serif;
+  font-weight: 700;
+  margin-bottom: 1rem;
+  color: #000;
+}
+
+.about-genova__text h1 {
+  font-size: 2.1rem;
+}
+
+.about-genova__text h2 {
+  font-size: 1.8rem;
+}
+
+.about-genova__media img {
+  width: 100%;
+  border-radius: 2.25rem;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.18);
+  display: block;
+}
+
+@media (max-width: 900px) {
+  .about-genova__row {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+
+  .about-genova__row--reverse {
+    grid-auto-flow: row;
+  }
+}


### PR DESCRIPTION
### Motivation
- Create an About page that matches the provided design using the existing hero images and site typography.  
- Ensure headings use `Roboto` and body text uses `Raleway` and that the layout is responsive for narrow screens.

### Description
- Add a new page markup at `about.md` that introduces two image/text sections and references `/assets/images/hiker.png` and `/assets/images/handshake.png.png`.  
- Append dedicated About page styles to `assets/css/custom.css` under the `.about-genova` namespace, including grid layout, typography rules for `h1` / `h2`, image styling, and a mobile media query.  
- Leverage existing font imports in `_includes/head/custom.html` so headings use `Roboto` and body text uses `Raleway`.

### Testing
- Attempted a site build with `jekyll build`, which failed because Jekyll is not available in the environment, so the visual output could not be automatically verified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ffe3739fc832e954912bff0e4c866)