### PR TITLE
Center about page media layout

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -297,6 +297,7 @@ body * {
   grid-template-columns: 1fr 1fr;
   gap: 4rem;
   align-items: center;
+  justify-items: center;
 
   max-width: 1100px;   /* 👈 this is the magic */
   margin: 0 auto;      /* 👈 centers the whole row */
@@ -313,11 +314,11 @@ body * {
 .about-genova__media {
   display: flex;
   width: 100%;
-  justify-content: flex-end; /* row 1 image hugs right edge */
+  justify-content: center;
 }
 
 .about-genova__row--reverse .about-genova__media {
-  justify-content: flex-start; /* row 2 image hugs left edge */
+  justify-content: center;
 }
 
 .about-genova__media img {


### PR DESCRIPTION
### Motivation
- Align the About page with the provided mock by centering row content and media so text and images sit evenly within each column.

### Description
- Modify `assets/css/custom.css` to add `justify-items: center` to `.about-genova__row` and change `.about-genova__media` and `.about-genova__row--reverse .about-genova__media` to use `justify-content: center` instead of edge-aligned values.

### Testing
- No automated tests were run for this frontend-only CSS change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69802d08b234832ea0e95264b77a4e15)