### PR TITLE
Increase navbar height and logo sizing to avoid squashed brand

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,5 @@
 title: 𝙶𝙴𝙽𝙾𝚅𝙰
+logo: "/assets/images/logo.png"
 description: Student-led STEM articles and research
 url: "https://www.genovag.org"
 baseurl: ""

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -17,7 +17,7 @@ color: #000 !important;
 /* Less vertical space above/below the navbar */
 .masthead {
 border-bottom: none !important;
-padding: 1.1rem 0 !important;
+padding: 1.65rem 0 !important;
 }
 
 /* Bring logo + nav closer to screen edges */
@@ -73,20 +73,24 @@ font-weight: 500 !important;
 opacity: 0.55 !important;
 }
 
-/* Force logo text to pure black */
-.masthead #site-nav.greedy-nav .site-title,
-.masthead #site-nav.greedy-nav .site-title a {
-color: #000 !important;
+/* Render brand as image logo instead of text */
+.masthead #site-nav.greedy-nav .site-title {
+display: none !important;
 }
 
-/* Logo styling + nudge */
-.masthead #site-nav.greedy-nav .site-title a {
-font-size: 1.5rem !important;
-font-weight: 700 !important;
-letter-spacing: -0.03em !important;
+.masthead #site-nav.greedy-nav .site-logo {
+margin-right: auto !important;
 position: relative;
-top: -6px;
+top: 0;
 left: -20px;
+}
+
+.masthead #site-nav.greedy-nav .site-logo img {
+display: block;
+height: 52px;
+width: auto;
+max-width: none;
+max-height: none;
 }
 
 /* =========================================================


### PR DESCRIPTION
### Motivation
- The site logo was still appearing cramped and potentially distorted inside the masthead due to a too-small navbar height and theme constraints on the image.
- A small vertical nudge was being used to compensate for height, which is brittle across viewports and themes.

### Description
- Added `logo: "/assets/images/logo.png"` to `_config.yml` so the theme renders the image-based `.site-logo` element.
- Hid the textual site title by setting `.masthead #site-nav.greedy-nav .site-title { display: none !important; }` so the image logo is used instead.
- Increased masthead vertical padding from `1.1rem` to `1.65rem` and removed the upward nudge by changing `.site-logo { top: 0; }` so the logo sits naturally in a taller header.
- Increased `.site-logo img` height to `52px`, kept `width: auto`, and added `max-height: none` and `max-width: none` to avoid theme clipping and preserve the logo's aspect ratio.

### Testing
- Ran `bundle exec jekyll build`, which failed in this environment due to a missing `Gemfile`/`.bundle` directory (validation not possible here).
- Attempted a Playwright screenshot against `http://127.0.0.1:4000`, which failed with `ERR_EMPTY_RESPONSE` because no local site server was running (capture not possible here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d1f0210e0832e86d092da9f8b7c60)